### PR TITLE
fix(regex): find package difference with tilda

### DIFF
--- a/src/diff-service.ts
+++ b/src/diff-service.ts
@@ -6,7 +6,7 @@ interface IComputedPackage {
   [packagename: string]: string[];
 }
 
-const PACKAGE_REGEX = /(?<packageName>.*)@(?:(?<semverPin>[\^\$])?(?<major>\d)(?:\.(?<minor>\d))?(?:\.(?<patch>\d))?(?:-(?<prerelease>[0-9a-zA-Z-]+)(?:.(?<prereleaseVersion>[0-9a-zA-Z]+))?)?(?:\+(?<metadata>[0-9a-zA-Z-]+)(?:.(?<metadataVersion>[0-9a-zA-Z]+))?)?|\*)/;
+const PACKAGE_REGEX = /(?<packageName>.*)@(?:(?<semverPin>[\^|\~\$])?(?<major>\d)(?:\.(?<minor>\d))?(?:\.(?<patch>\d))?(?:-(?<prerelease>[0-9a-zA-Z-]+)(?:.(?<prereleaseVersion>[0-9a-zA-Z]+))?)?(?:\+(?<metadata>[0-9a-zA-Z-]+)(?:.(?<metadataVersion>[0-9a-zA-Z]+))?)?|\*)/;
 
 export const DiffService = {
   computeHashmapOfPackageAndVersionList(


### PR DESCRIPTION
I have an automatic process to spit out any updated to libraries we depend on. The current regex to pull out package names/versions will fail to find a difference for something like the following:

Old:

```
vega-typings@~0.19.0:
  version "0.19.1"
  resolved "https://nexus-trunk.udev.six3/repository/npm/vega-typings/-/vega-typings-0.19.1.tgz#a53949143fa37721ae7bd146bbb9add5c78aca52"
  integrity sha512-OSyNYwMJ8FayTTNU/gohprbt1EFQBpoiMPP9p2vqo1O9z45XVnotQ92jYHAhraI6gWiMIIfo4OjPbSe/GX7etg==
  dependencies:
    vega-util "^1.15.2"
```
    
New:

```
vega-typings@~0.19.2:
  version "0.19.2"
  resolved "https://nexus-trunk.udev.six3/repository/npm/vega-typings/-/vega-typings-0.19.2.tgz#374fc1020c1abb263a0be87de28d1a4bd0526c3f"
  integrity sha512-YU/S9rDk4d+t4+4eTa9fzuw87PMNteeVtpcL51kUO8H7HvGaoW7ll8RHKLkR0NYBEGPRoFDKUxnoyMvhgjsdYw==
  dependencies:
    vega-util "^1.15.2"
```
    
I updated the regex to work for both ^ and ~, now it correctly shows that there is a difference.